### PR TITLE
Hide mouse pointer if surface is fully dimmed

### DIFF
--- a/man/dim.1.scd
+++ b/man/dim.1.scd
@@ -34,7 +34,7 @@ detected after its timeout, swaylock will be run, locking the screen.
 
 \-a, --alpha <ALPHA>
 	Set the *alpha* value of the overlay, 0.0 being transparent and 1.0 being
-	solid black. Default is 0.5.
+	solid black. When solid, cursor will be hidden. Default is 0.5.
 
 \--gen-completions <PATH>
 	Generates completions for all supported shells at the given path.

--- a/src/dim.rs
+++ b/src/dim.rs
@@ -426,12 +426,17 @@ impl PointerHandler for DimData {
         &mut self,
         _conn: &smithay_client_toolkit::reexports::client::Connection,
         _qh: &QueueHandle<Self>,
-        _pointer: &wl_pointer::WlPointer,
+        pointer: &wl_pointer::WlPointer,
         events: &[PointerEvent],
     ) {
         for e in events {
             match e.kind {
-                PointerEventKind::Enter { .. } | PointerEventKind::Leave { .. } => (),
+                PointerEventKind::Enter { serial } => {
+                    if self.alpha == 1.0 {
+                        pointer.set_cursor(serial, None, 0, 0);
+                    }
+                },
+                PointerEventKind::Leave { .. } => {}
                 _ => {
                     debug!("Mouse event");
                     self.exit = true;

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -19,7 +19,7 @@ pub struct DimOpts {
     #[arg(
         short,
         long,
-        help = format!("0.0 is transparent, 1.0 is opaque, [default: {DEFAULT_ALPHA}]")
+        help = format!("0.0 is transparent, 1.0 is opaque. When opaque, cursor will be hidden. [default: {DEFAULT_ALPHA}]")
     )]
     pub alpha: Option<f32>,
 


### PR DESCRIPTION
Hello, my monitor is capable of automatically disabling backlight, if the surface is fully black, so i switched from using WM's dpms to dim and it works much more reliable, just my cursor is too flashy and monitor doesn't recognize surface as fully black, this PR should help with it without introducing new useless flags.

I can't imagine that someone would want to have mouse pointer on a fully black surface, but if you disagree, I can make it a flag for CLI.