### PR TITLE
chore: Update Cargo.toml use repository instead of homepage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dim-screen"
 authors = ["Marcelo Hernandez <marcelohdez.inq@gmail.com>"]
 description = "Native Wayland screen dimming tool"
-homepage = "https://github.com/marcelohdez/dim"
+repository = "https://github.com/marcelohdez/dim"
 license = "GPL-3.0-only"
 keywords = ["wayland", "smithay"]
 


### PR DESCRIPTION
According to the [manifest](https://doc.rust-lang.org/cargo/reference/manifest.html) it seems the `repository` field is preferable.  More explanation https://github.com/szabgab/rust-digger/issues/104