### PR TITLE
new: fade animation on start

### DIFF
--- a/man/dim.1.scd
+++ b/man/dim.1.scd
@@ -35,6 +35,10 @@ detected after its timeout, swaylock will be run, locking the screen.
 	Set the *alpha* value of the overlay, 0.0 being transparent and 1.0 being
 	solid black. When solid, cursor will be hidden. Default is 0.5.
 
+\-f, --fade <FADE_DURATION>
+	Duration of fade-in animation in seconds. Must be at least 0, and at most
+	equal to the duration option above. Default is 0.5.
+
 \-p, --passthrough
 	Make dim ignore input, passing it to the surfaces behind it, making dim act as
 	a way to lower your brightness artificially. You probably want to set the
@@ -69,5 +73,6 @@ options are alpha, duration and passthrough as seen above, example config:
 # i am a comment!
 duration = 30
 alpha = 0.5
+fade = 0.5
 passthrough = false
 ```

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -49,15 +49,18 @@ impl BufferManager {
                     .create_buffer(1, 1, 4, wl_shm::Format::Argb8888)
                     .expect("Failed to get buffer from slot pool!");
 
-                // ARGB is actually backwards being little-endian, so we set BGR to 0 for black so
-                (0..3).for_each(|i| {
-                    canvas[i] = 0;
-                });
-                // then, we set pre-multiplied alpha
-                canvas[3] = (u8::MAX as f32 * alpha) as u8;
-
+                BufferManager::paint(canvas, alpha);
                 BufferType::Shared(buffer)
             }
         }
+    }
+
+    pub fn paint(canvas: &mut [u8], alpha: f32) {
+        // RGB
+        (0..3).for_each(|i| {
+            canvas[i] = 0;
+        });
+        // ...A
+        canvas[3] = (u8::MAX as f32 * alpha) as u8;
     }
 }

--- a/src/dim.rs
+++ b/src/dim.rs
@@ -60,6 +60,7 @@ pub struct DimData {
     alpha: f32,
     passthrough: bool,
     start_time: Instant,
+    fade_sec: f32,
     surfaces: HashMap<WlOutput, DimSurface>,
 
     keyboard: Option<wl_keyboard::WlKeyboard>,
@@ -101,6 +102,7 @@ impl DimData {
             alpha: opts.alpha(),
             passthrough: opts.passthrough,
             start_time: Instant::now(),
+            fade_sec: opts.fade(),
             surfaces: HashMap::new(),
 
             keyboard: None,
@@ -225,10 +227,9 @@ impl CompositorHandler for DimData {
     ) {
         for view in self.surfaces.values_mut() {
             let elapsed_sec = self.start_time.elapsed().as_millis() as f32 / 1000.;
-            let fade_sec = 0.5;
 
-            if elapsed_sec <= fade_sec {
-                let alpha = self.alpha * (elapsed_sec / fade_sec);
+            if elapsed_sec <= self.fade_sec {
+                let alpha = self.alpha * (elapsed_sec / self.fade_sec);
                 match &mut self.buffer_mgr {
                     BufferManager::SinglePixel(..) => {
                         view.set_back_buffer(self.buffer_mgr.get_buffer(qh, alpha));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub use surface::DimSurface;
 pub mod consts {
     pub const DEFAULT_DURATION: u64 = 30;
     pub const DEFAULT_ALPHA: f32 = 0.5;
+    pub const DEFAULT_FADE: f32 = 0.5;
 
     pub const CONFIG_FILENAME: &str = "config.toml";
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -5,7 +5,7 @@ use clap::{CommandFactory, Parser, ValueEnum};
 use clap_complete::{generate_to, Shell};
 use serde::Deserialize;
 
-use crate::{consts::DEFAULT_ALPHA, consts::DEFAULT_DURATION};
+use crate::consts::{DEFAULT_ALPHA, DEFAULT_DURATION, DEFAULT_FADE};
 
 #[derive(Debug, Deserialize, Parser)]
 #[command(author, version, about)]
@@ -23,6 +23,14 @@ pub struct DimOpts {
         help = format!("0.0 is transparent, 1.0 is opaque. When opaque, cursor will be hidden. [default: {DEFAULT_ALPHA}]")
     )]
     alpha: Option<f32>,
+
+    #[arg(
+        short,
+        long,
+        help = format!("Fade-in animation duration in seconds. [default: {DEFAULT_FADE}]")
+    )]
+    #[serde(default)]
+    pub fade: Option<f32>,
 
     #[arg(
         short,
@@ -73,6 +81,14 @@ impl DimOpts {
             }
         }
 
+        if let Some(fade) = self.fade {
+            if !(0.0..=self.duration() as f32).contains(&fade) {
+                return Err(anyhow!(
+                    "Fade must be at least 0 and as much as the duration option."
+                ));
+            }
+        }
+
         Ok(())
     }
 
@@ -84,5 +100,10 @@ impl DimOpts {
     /// Get user desired duration or the default value.
     pub fn duration(&self) -> u64 {
         self.duration.unwrap_or(DEFAULT_DURATION)
+    }
+
+    /// Get user desired fade or the default value.
+    pub fn fade(&self) -> f32 {
+        self.fade.unwrap_or(DEFAULT_FADE)
     }
 }

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -75,17 +75,13 @@ impl DimSurface {
             .set_destination(self.width as _, self.height as _);
     }
 
-    pub fn set_damaged(&mut self, damaged: bool) {
-        self.damaged = damaged;
-    }
-
     pub fn set_back_buffer(&mut self, back_buffer: BufferType) {
         self.back_buffer = back_buffer;
         self.damaged = true;
     }
 
     pub fn back_buffer_mut(&mut self) -> &mut BufferType {
-        self.damaged = true;
+        self.damaged = true; // we're most likely changing something.
         &mut self.back_buffer
     }
 }


### PR DESCRIPTION
- [x] Fade into desired alpha on startup with double buffering
- [x] Test on major compositors:
  - [x] Niri
  - [x] Sway
  - [x] Hyprland
- [x] Add `-f,--fade` option to set duration in seconds for fade-in animation, along with config.
- [x] Add to manpage
- [x] Fix [fade check](https://github.com/marcelohdez/dim/pull/19#discussion_r2644911578)

Closes #18 